### PR TITLE
Added integer level codes

### DIFF
--- a/standards/log_message.md
+++ b/standards/log_message.md
@@ -5,6 +5,7 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 The message format MUST be JSON.
 
 The message MUST contain the following top-level keys: `level`, `message`:
+
 - `level` MUST be a **string** of one of the following values (case-sensitive) and MUST follow this order of severity (from least to greatest): `DEBUG`, `INFO`, `NOTICE`, `WARNING`, `ERROR`, `CRITICAL`, `ALERT`, or `EMERGENCY`.
 - `message` MUST be a **string** and SHOULD contain a message useful for debugging/error reporting.
 


### PR DESCRIPTION
Hi all,

This PR contains guidance about how to add a corresponding integer for each log `level`.

I know there was some discussion about his in #6. I find it helpful to have an integer because it simplifies the process of doing a metric filter in CloudWatch. For example, I can search for: `{$.levelCode<=4}` and ensure no log messages are missed.

Since not every dev may find this useful, I added this under the `MAY` guidelines. But for developers that _do_ find this useful, it will be good to have consistent usage.

I'm assigning the devs that reviewed #6 as reviewers for this PR, but comments from everyone are welcome.

Thanks!