### PR TITLE
Modified aggregation language and linked alerting

### DIFF
--- a/standards/logging.md
+++ b/standards/logging.md
@@ -29,12 +29,14 @@ Additional key/values of any type MAY be included and MUST NOT break functionali
 
 ## Aggregation
 
-Any logging SHOULD be sent to aggregation service such as Loggly or CloudWatch.
+Any logging MUST be sent to CloudWatch.
+
+Services built prior to this standard, MAY send logs to another aggregation service like Loggly.
 
 ## Metrics & Exception Notification
 
 We SHOULD use log parsing for generating metrics & exception notification.  
-**A severity of `ERROR` & above means human beings MUST be notified.**
+**A severity of `ERROR` & above means human beings MUST be [notified](alerting.md).**
 
 ## Rotation
 


### PR DESCRIPTION
As I was thinking through the alerting standard, I realized that it would be a lot easier if we standardized our logging to use CloudWatch. It seems like we're heading in this direction anyway. Are you okay with firm language stating we MUST use CloudWatch going forward? Previous services would be exempt, of course.