### PR TITLE
Add a coding-standards guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repo is intended to be used for information relevant to the NYPL Engineerin
 ### Standards
 
 * [Logging](standards/logging.md)
+* [Coding Style](standards/coding-standards.md)
 
 ### Security
 

--- a/standards/coding-standards.md
+++ b/standards/coding-standards.md
@@ -1,0 +1,24 @@
+# Coding Standards
+
+Apps MAY enforce a rigorous coding style.  
+Different languages have different opinions about uniformity.
+
+If a project wants to enforce a style - it SHOULD be called
+out in a conspicious way (e.g. its README) **and** enforced
+via the project's test suite.
+
+**Example:**
+
+A JavaScript application is meant to conform to [standardjs](https://standardjs.com/), its test suite SHOULD
+fail if `standard` fails.
+
+One way of doing this is by using something like this in `package.json`:  
+
+```javascript
+// ...snip
+"scripts": {
+    "test": "./node_modules/.bin/standard && ./node_modules/.bin/mocha test",
+    "start": "node app.js"
+  },
+// ...snip
+```


### PR DESCRIPTION
This is very hands off - there are no MUSTs.

Mostly because different languages have different opinions about uniformity & 
we've never had a flame war about tabs vs spaces, etc.

The strongest stand I take is that:

> ...If a project wants to enforce a style - it SHOULD be called out in a conspicious way (e.g. its README) **and** enforced via the project's test suite.

