### PR TITLE
Added guidance about log message size limits

### DIFF
--- a/standards/logging.md
+++ b/standards/logging.md
@@ -29,6 +29,8 @@ The message MAY also contain the following top-level keys:
 
 Additional key/values of any type MAY be included and MUST NOT break functionality.
 
+Developers SHOULD be aware of message size limits to prevent malformed JSON. For example, CloudWatch [truncates log messages](http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html) to 256 KB.
+
 ## Aggregation
 
 Any logging SHOULD be sent to aggregation service such as Loggly or CloudWatch.


### PR DESCRIPTION
So, I noticed that CloudWatch truncates log messages at 256 KB. This can cause message to have malformed JSON. This happened to me so I thought I should add some guidance here.