### PR TITLE
Integrate aws profile names convention

### DIFF
--- a/standards/naming-conventions.md
+++ b/standards/naming-conventions.md
@@ -60,16 +60,29 @@ An incorrect example would be `ItemService-dev`. Although it uses upper camel ca
 All development environment strings MUST adhere to one of three allowable types:
 
 - `-development`
+
 - `-qa`
+
 - `-production`
+
+### Profile Names
+AWS profile name format MUST be in lower snake case, delimited by a hyphen ("-").
+
+The profile name SHOULD be one of the following:
+
+- `Account ID`
+
+- `Alias`
+
+Examples: `nypl-digital-dev`, `nypl-sandbox`, `nypl`
 
 ### Metrics
 
-TODO: Add metrics naming conventions
+See [Monitoring & Alarms](/alerting.md)
 
 ### Alarms
 
-TODO: Add metrics naming conventions
+See [Monitoring & Alarms](/alerting.md)
 
 ## Repository Names
 

--- a/standards/naming-conventions.md
+++ b/standards/naming-conventions.md
@@ -66,7 +66,7 @@ All development environment strings MUST adhere to one of three allowable types:
 - `-production`
 
 ### Profile Names
-AWS profile name format MUST be in kebab-case.
+AWS profile name format MUST be in kebab-case/dasherized.
 
 The profile name SHOULD be one of the following:
 

--- a/standards/naming-conventions.md
+++ b/standards/naming-conventions.md
@@ -66,7 +66,7 @@ All development environment strings MUST adhere to one of three allowable types:
 - `-production`
 
 ### Profile Names
-AWS profile name format MUST be in lower snake case, delimited by a hyphen ("-").
+AWS profile name format MUST be in kebab-case.
 
 The profile name SHOULD be one of the following:
 

--- a/standards/naming-conventions.md
+++ b/standards/naming-conventions.md
@@ -78,11 +78,11 @@ Examples: `nypl-digital-dev`, `nypl-sandbox`, `nypl`
 
 ### Metrics
 
-See [Monitoring & Alarms](/alerting.md)
+See [Monitoring & Alarms](../standards/alerting.md)
 
 ### Alarms
 
-See [Monitoring & Alarms](/alerting.md)
+See [Monitoring & Alarms](../standards/alerting.md)
 
 ## Repository Names
 


### PR DESCRIPTION
This PR adds the AWS Profile Names section under Naming Conventions and inserts the links that reference Monitoring & Alarms for AWS.

This addresses #31 