### PR TITLE
Add documentation section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY/OPTIONAL, in these doc
 
 Links to documentation relevant to NYPL applications and services.
 
-* [Platform API](https://docs.google.com/document/d/1p3q9OT9latXqON20WDh4CNPxIShUunfGgqT163r-Caw/edit?userstoinvite=seanredmond@nypl.org&ts=59ba9ea8&actionButton=1#heading=h.3cnbzjhn6z8u)
+* [Platform API](https://docs.google.com/document/d/1p3q9OT9latXqON20WDh4CNPxIShUunfGgqT163r-Caw/edit?usp=sharing)

--- a/README.md
+++ b/README.md
@@ -31,4 +31,10 @@ The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY/OPTIONAL, in these doc
 
 ### Data
 
-* :link: [Data Repo](https://github.com/NYPL/nypl-core)
+* [Data Repo](https://github.com/NYPL/nypl-core)
+
+### Documentation
+
+Links to documentation relevant to NYPL applications and services.
+
+* [Platform API](https://docs.google.com/document/d/1p3q9OT9latXqON20WDh4CNPxIShUunfGgqT163r-Caw/edit?userstoinvite=seanredmond@nypl.org&ts=59ba9ea8&actionButton=1#heading=h.3cnbzjhn6z8u)


### PR DESCRIPTION
I thought it might be helpful to add a "Documentation" section to the main README to link to documentation that is somewhat relevant across projects/applications. Maybe we can try this out and see if it becomes overwhelming. Thoughts?