### PR TITLE
Add Secret Management guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY/OPTIONAL, in these doc
 
 * [General](security/README.md)
 * [OAuth](security/oauth.md)
+* [Secrets Management](security/secrets.md)
 
 ## Other Documentation
 

--- a/security/README.md
+++ b/security/README.md
@@ -18,6 +18,8 @@ Applications MUST NOT expose private credentials to users or in source control (
 
 Applications SHOULD use environment variables to store private credentials and SHOULD be encrypted using [AWS KMS](http://docs.aws.amazon.com/kms/latest/APIReference/API_Decrypt.html) or other encryption service.
 
+- If storing or sharing secrets, they MUST be stored or shared according to the [Secret Management](secrets.md) guidelines.
+
 Front-end applications MUST NOT store any private credentials in browser cache or cookies.
 
 Applications SHOULD protect against [XSS and CSRF](http://www.redotheweb.com/2015/11/09/api-security.html) attacks.

--- a/security/secrets.md
+++ b/security/secrets.md
@@ -55,5 +55,5 @@ aws ssm put-parameter --name '/development/testservice/credentials/admin' --type
 Getting a parameter:
 
 ```
-aws ssm get-parameter --name '/development/testservice/credentials/admin'  --with-decryption --profile nypl-digital-dev
+aws ssm get-parameter --name '/development/testservice/credentials/admin' --with-decryption --profile nypl-digital-dev
 ```

--- a/security/secrets.md
+++ b/security/secrets.md
@@ -1,0 +1,49 @@
+# Secrets Management
+
+Secrets and credentials (e.g. API keys, database logins, or other credentials) SHOULD be stored so they are not lost and can be shared appropriately. 
+
+If secrets are to be stored or shared, they MUST be stored or shared using [AWS Parameter Store](http://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html).
+
+## Parameter Store
+
+### Name conventions
+
+Parameter names MUST use a hierarchy and list the environment name and other descriptors:
+
+```
+environment/{service or application name}/{other descriptors}
+```
+
+For example:
+
+```
+production/bibservice/database-credentials/admin
+```
+
+### Value conventions
+
+Values MUST be stored as the `SecureString` type.
+
+Values SHOULD be encrypted using the KMS Key ID `d1a6a910-1455-4d62-b789-f9910bd2df68`. 
+
+A description SHOULD be provided (using the `--description` flag).
+
+Values MUST be in JSON. For example:
+
+```
+{"username":"admin","password":"password123"}
+```
+
+### Sample AWS command line commands
+
+Adding a parameter:
+
+```
+aws ssm put-parameter --name '/development/testservice/credentials/admin' --type 'SecureString' --key-id d1a6a910-1455-4d62-b789-f9910bd2df68 --description 'This describes this key' --value '{"username":"admin","password":"password123"}' --profile nypl-digital-dev
+```
+
+Getting a parameter:
+
+```
+aws ssm get-parameter --name '/development/testservice/credentials/admin'  --with-decryption --profile nypl-digital-dev
+```

--- a/security/secrets.md
+++ b/security/secrets.md
@@ -34,6 +34,16 @@ Values MUST be in JSON. For example:
 {"username":"admin","password":"password123"}
 ```
 
+### Parameter Store limits
+
+Developers SHOULD be aware of the following limits:
+
+- Name hierarchy has a maximum of 5 levels.
+- Maximum length of `name` is 2,048 characters.
+- Maximum length of `value` is 4,096 characters.
+
+See the [API Reference](http://docs.aws.amazon.com/systems-manager/latest/APIReference/API_Parameter.html) for current limits.
+
 ### Sample AWS command line commands
 
 Adding a parameter:

--- a/security/secrets.md
+++ b/security/secrets.md
@@ -26,7 +26,7 @@ Values MUST be stored as the `SecureString` type.
 
 Values SHOULD be encrypted using the KMS Key ID `alias/secrets-key`. 
 
-A description SHOULD be provided (using the `--description` flag).
+A description SHOULD be provided (e.g. using the `--description` flag).
 
 Values MUST be in JSON. For example:
 

--- a/security/secrets.md
+++ b/security/secrets.md
@@ -8,17 +8,20 @@ If secrets (e.g. API keys, database logins, or other credentials) are to be stor
 
 ### Name conventions
 
-Parameter names MUST use a hierarchy and list the environment name and other descriptors:
+Parameter names MUST use a hierarchy and list the environment name and other descriptors.
 
-```
-environment/{service or application name}/{other descriptors}
-```
+The name MUST include the following:
 
-For example:
+- The first segment of the parameter name MUST be environment/stage/tier if applicable.
+- The service that this is a parameter for.
+- The app that uses this secret. This could be omitted if it's a resource shared by multiple apps.
+- A description of what this is.
 
-```
-production/bibservice/database-credentials/admin
-```
+Examples may be:
+
+- `/production/mms/rds/password-for-mms_productions-root-user`
+- `/production/elasticcache/my-cluser-name/password`
+- `/loggly/my-loggly-user-name/api-key` (environment/stage/tier isn't applicable)
 
 ### Value conventions
 

--- a/security/secrets.md
+++ b/security/secrets.md
@@ -1,8 +1,8 @@
 # Secrets Management
 
-Secrets and credentials (e.g. API keys, database logins, or other credentials) SHOULD be stored so they are not lost and can be shared appropriately. 
+If secrets (e.g. API keys, database logins, or other credentials) are to be stored or shared, they MUST be stored or shared in one secure place, to signify one source of truth and to make resources easier to find.
 
-If secrets are to be stored or shared, they MUST be stored or shared using [AWS Parameter Store](http://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html).
+[AWS Parameter Store](http://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html) SHOULD be used to store secrets.
 
 ## Parameter Store
 

--- a/security/secrets.md
+++ b/security/secrets.md
@@ -24,7 +24,7 @@ production/bibservice/database-credentials/admin
 
 Values MUST be stored as the `SecureString` type.
 
-Values SHOULD be encrypted using the KMS Key ID `d1a6a910-1455-4d62-b789-f9910bd2df68`. 
+Values SHOULD be encrypted using the KMS Key ID `alias/secrets-key`. 
 
 A description SHOULD be provided (using the `--description` flag).
 

--- a/security/secrets.md
+++ b/security/secrets.md
@@ -57,3 +57,27 @@ Getting a parameter:
 ```
 aws ssm get-parameter --name '/development/testservice/credentials/admin' --with-decryption --profile nypl-digital-dev
 ```
+
+## Encrypting/Decrypting
+
+### Using the AWS Command Line
+
+To encrypt a secret using the AWS command line:
+
+```
+aws kms encrypt --key-id alias/lambda-default --profile nypl-digital-dev --query CiphertextBlob --output text --plaintext "THIS IS A SECRET"
+```
+
+returns:
+
+`AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAGkwZwYJKoZIhvcNAQcGoFowWAIBADBTBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDHM+CBbD63yvLYX7YAIBEIAmPAZ1EOrQMd5GRao2MTOyY16JZmMhOgDNJWvy1V3eWr1xHIWIuRo=`
+
+To decrypt a secret using the AWS command line:
+
+```
+aws kms decrypt --profile nypl-digital-dev --query Plaintext --output text --ciphertext-blob fileb://<(echo "AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAGkwZwYJKoZIhvcNAQcGoFowWAIBADBTBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDK5NDY0/rIiVt3rp4AIBEIAm5tjVxfouymAm2+UDCc6aYesUxlAXvU5lgI9VlQBYIrl7LozlQ2o=" | base64 --decode) | base64 --decode
+```
+
+returns:
+
+`THIS IS A SECRET`

--- a/security/secrets.md
+++ b/security/secrets.md
@@ -34,9 +34,9 @@ Values MUST be in JSON. For example:
 {"username":"admin","password":"password123"}
 ```
 
-### Parameter Store limits
+### Limits
 
-Developers SHOULD be aware of the following limits:
+Developers SHOULD be aware of the following limits with Parameter Store:
 
 - Name hierarchy has a maximum of 5 levels.
 - Maximum length of `name` is 2,048 characters.

--- a/security/secrets.md
+++ b/security/secrets.md
@@ -49,7 +49,7 @@ See the [API Reference](http://docs.aws.amazon.com/systems-manager/latest/APIRef
 Adding a parameter:
 
 ```
-aws ssm put-parameter --name '/development/testservice/credentials/admin' --type 'SecureString' --key-id d1a6a910-1455-4d62-b789-f9910bd2df68 --description 'This describes this key' --value '{"username":"admin","password":"password123"}' --profile nypl-digital-dev
+aws ssm put-parameter --name '/development/testservice/credentials/admin' --type 'SecureString' --key-id alias/secrets-key --description 'This describes this key' --value '{"username":"admin","password":"password123"}' --profile nypl-digital-dev
 ```
 
 Getting a parameter:


### PR DESCRIPTION
Hi all,

This is a draft of guidelines intended to used for **storing** and **sharing** secrets 🔑  more securely .

It relies on [AWS SSM Parameter Store](http://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html) which may or may not be the best tool. As far as I know, Parameter Store generally has good feedback and there is a lot of tooling (e.g. [https://github.com/nak2k/node-ssm-params](https://github.com/nak2k/node-ssm-params)) as well as just the regular AWS SDK.

Hopefully this can kick off some good conversation... and help us stop sharing/storing secrets in Slack, email, Google docs, etc. 😉 