### PR TITLE
Add data warehouse to onboarding

### DIFF
--- a/on-off-board/onboarding.md
+++ b/on-off-board/onboarding.md
@@ -57,7 +57,9 @@ A developer will generally need accounts for the following services:
         - [nypl/prod](https://nypl.signin.aws.amazon.com/console)
         - [nypl-dev](https://nypl-dev.signin.aws.amazon.com/console)
         - [nypl-labs](https://nypl-labs.signin.aws.amazon.com/console)
-    
+- Data Warehouse DB credential
+    - [https://github.com/NYPL/data-warehouse#users](https://github.com/NYPL/data-warehouse#users)
+
 *&#42; uses [NYPL/ServiceNow](https://nyplprod.service-now.com) credentials for authentication*
 
 ## 3. Set up keys


### PR DESCRIPTION
Just adding a note about Data Warehouse DB credentials to the onboarding/offboarding section. 

Sending PR for visibility. Going to auto-merge.