### PR TITLE
Add documentation about SQS naming conventions

### DIFF
--- a/standards/naming-conventions.md
+++ b/standards/naming-conventions.md
@@ -20,6 +20,7 @@ Establishing proper naming will help each developer by:
     + [Lambdas](#lambdas)
     + [Metrics](#metrics)
     + [Alarms](#alarms)
+    + [SQS](#sqs)
   * [Repository Names](#repository-names)
   * [Code](#code)
     + [Camel Case](#camel-case)
@@ -83,6 +84,30 @@ See [Monitoring & Alarms](../standards/alerting.md)
 ### Alarms
 
 See [Monitoring & Alarms](../standards/alerting.md)
+
+### SQS
+
+#### Naming
+
+Queues MUST be named in a way that describes:
+
+1.  _What_ is is the queue.
+2.  _Where_ the destination is for these records.
+
+The _What_ and the _Where_ SHOULD be separated by the word "for", unless
+it's awkward grammatically.   
+Finally, the queue name MUST be suffixed with
+the environment name.
+
+e.g. `user-profile-updates-for-sierra-development` tells us:
+
+1. The queue contains records that represent a user's profile update.
+2. The records will be sent to sierra.
+3. It is the `development` environment.
+
+#### Documenting
+
+Queues should be documented in https://github.com/NYPL/aws.
 
 ## Repository Names
 


### PR DESCRIPTION
Hey @thisisstephenbetts 

This documents the naming convention for SQS queues.
Let me know if you think there should be edits or additions.
