### PR TITLE
Project-specific norms for PR review

### DIFF
--- a/standards/peer-review.md
+++ b/standards/peer-review.md
@@ -13,14 +13,14 @@
 - It MAY involve a team member who is less experienced with the tech stack.
 
   - Example: A team member who is familiar with PHP can sit down with a team member familiar with Ruby on Rails, walking through the idea behind the PHP code, followed by a list concrete tests showing the code works.
-  
+
 ## Pull Request Workflow
 
 A common type of peer review involves two or more developers reviewing a pull request from a code repository.
-
 
 - Developers when submitting pull request, SHOULD mark at least one (1) developer as reviewer.
 
 - Reviewers receiving pull request SHOULD accept the invitation and SHOULD review the code.
 
-- If reviewers do not respond to pull request within 3rd business day, developer sending in request SHOULD follow up with a one-on-one peer review.
+- If reviewers do not respond to a review request by the 3rd business day, the author SHOULD follow up with a request for an in-person review.  Project teams MAY establish a rhythm to increase predictability.
+  - Examples: "aim for a 4-hour turn-around", "review must be complete by 10am the next business day", or "send a Slack reminder for people who prefer").


### PR DESCRIPTION
The MyLibraryNYC team established some norms to increase predictability of PR review on the project, so I'm suggesting that other teams explicitly set their own norms for PR review too.