### PR TITLE
Fix broken link

### DIFF
--- a/standards/travis-ci.md
+++ b/standards/travis-ci.md
@@ -71,7 +71,7 @@ To configure Travis to deploy to Elastic Beanstalk:
         repo: NYPL-discovery/discovery-api
         branch: development # specify the branch for travis to watch
    ```
-Labmda example:
+Lambda example:
   ```yml
   deploy:
   - provider: script

--- a/standards/travis-ci.md
+++ b/standards/travis-ci.md
@@ -53,7 +53,7 @@ To configure Travis to deploy to Elastic Beanstalk:
 
  1. If you haven't already, run log in to Github through travis:
     `travis login --org`
- 2. *From the root directory of your app,* run the encrypted command stored in nypl-digital-dev parameter store: https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Parameters:Name=%5BEquals%5Dproduction/travis/add_aws;sort=Name which will automatically add encrypted credentials for AWS_ACCESS_KEY_ID_DEVELOPMENT, AWS_SECRET_ACCESS_KEY_DEVELOPMENT, AWS_SECRET_ACCESS_KEY_QA, AWS_SECRET_ACCESS_KEY_PRODUCTION, AWS_ACCESS_KEY_ID_QA, and AWS_ACCESS_KEY_ID_PRODUCTION to `.travis.yml`. (If this is a new Travis integration - or new to you - [ensure the repo is locally associated with the right Travis endpoint](#failure-to-decrypt-environmental-variables).)
+ 2. *From the root directory of your app,* run the encrypted command stored in nypl-digital-dev parameter store: https://console.aws.amazon.com/systems-manager/parameters/%252Fproduction%252Ftravis%252Fadd_aws/description?region=us-east-1 which will automatically add encrypted credentials for AWS_ACCESS_KEY_ID_DEVELOPMENT, AWS_SECRET_ACCESS_KEY_DEVELOPMENT, AWS_SECRET_ACCESS_KEY_QA, AWS_SECRET_ACCESS_KEY_PRODUCTION, AWS_ACCESS_KEY_ID_QA, and AWS_ACCESS_KEY_ID_PRODUCTION to `.travis.yml`. (If this is a new Travis integration - or new to you - [ensure the repo is locally associated with the right Travis endpoint](#failure-to-decrypt-environmental-variables).)
  3. Add `deploy` entries to `.travis.yml` for each deploy hook.
  Beanstalk example:
    ```yml


### PR DESCRIPTION
The current link to get the travis encryption command results in a redirect (to the wrong page) and a message:
```
You have been redirected to the newer AWS Systems Manager console. By July 1, 2019, Systems Manager links in your EC2 console will be removed. Please update your bookmarks before that date.
```

This branch fixes the link as well as a typo.