### PR TITLE
Adding a note on deprecating apps and codebases.

### DIFF
--- a/other/README.md
+++ b/other/README.md
@@ -72,12 +72,15 @@ Important and useful :link: links to other documentation and standards at NYPL.
 * Global Search
   * [Repository](https://github.com/NYPL/dgx-global-search)
   * [Web App](https://www.nypl.org/search/)
-* Blogs Beta
+* React Search/Locations
+  * [Repository](https://github.com/NYPL/dxp-react-search)
+  * [Web App](https://www.nypl.org/locations)
+* Blogs Beta - Deprecated
   * [Repository](https://github.com/NYPL/dgx-blogs)
   * [Web App](https://www.nypl.org/blog/beta/)
 
 ### Angular
-* Locations
+* Locations - Deprecated
   * [Repository](https://github.com/NYPL/locations-prototype)
   * [Web App](https://www.nypl.org/locations/)
 * Staff Profiles

--- a/other/README.md
+++ b/other/README.md
@@ -55,9 +55,8 @@ Important and useful :link: links to other documentation and standards at NYPL.
 * Homepage
   * [Repository](https://github.com/NYPL/dgx-homepage)
   * [Web App](https://www.nypl.org)
-* Staff Picks
+* Staff Picks - Deprecated
   * [Repository](https://github.com/NYPL/staff-picks)
-  * [Web App](https://www.nypl.org/books-music-dvds/recommendations/best-books/childrens)
 * New Arrivals
   * [Repository](https://github.com/NYPL/dgx-new-arrivals)
   * [Web App](https://www.nypl.org/books-music-dvds/new-arrivals)

--- a/other/deprecating-apps.md
+++ b/other/deprecating-apps.md
@@ -1,0 +1,12 @@
+# Deprecating Apps
+
+NYPL creates different applications for user interfaces, data pipeline flow, APIs, and more. While we maintain these applications, sometimes it's better to move from one platform to another for many reasons.
+
+When this happens, the developer(s) working on the new iteration of an application MUST let others know that the older version will be deprecated. This can reduce confusion on whether packages need to be updated for an app or codebase.
+
+The above also applies to codebases which will no longer be used, such as moving code from one codebase to another.
+
+Developer(s) MUST:
+* update the codebase's README with a deprecated and a no longer supported note
+* let the team know that an app/codebase is deprecated
+* update related documentation where the app/codebase's name comes up

--- a/other/updating-header.md
+++ b/other/updating-header.md
@@ -1,6 +1,6 @@
 # Changing NYPL Header
 
-The primary NYPL header is maintained as a React component distributed as an NPM module. To support non-React apps, a "header app" ensures the component may also be included via  aa `<script>` or as fully rendered HTML.
+The primary NYPL header is maintained as a React component distributed as an NPM module. To support non-React apps, a "header app" ensures the component may also be included via  a `<script>` or as fully rendered HTML.
 
 The following proposes a safe sequence of deployments for activing changes to the header across our apps. 
 
@@ -16,13 +16,13 @@ Changes to the component should follow [the instructions in the repo](https://gi
 
 Starting with the lowest traffic [React apps](https://github.com/NYPL/engineering-general/tree/master/other#reactnode) (excluding "Header App"), update the `dgx-header-component` dependency to use the new version. Proposed order:
 
- * [Get a library card](https://github.com/NYPL/nypl-library-card-app)
+ * [Library Card](https://github.com/NYPL/nypl-library-card-app)
  * [New Arrivals](https://github.com/NYPL/dgx-new-arrivals)
  * [BookLists](https://github.com/NYPL/dgx-booklists)
  * [SCC](https://github.com/NYPL-discovery/discovery-front-end)
  * [Global Search](https://github.com/NYPL/dgx-global-search)
- * [Blogs beta](https://github.com/NYPL/dgx-blogs)
  * [Homepage](https://github.com/NYPL/dgx-homepage)
+ * [React Search/Locations](https://github.com/NYPL/dxp-react-search)
 
 For each of these:
  - Clone the repo
@@ -50,7 +50,6 @@ Deploy the [Header App](https://github.com/NYPL/nypl-dgx-react-header) same as t
 ### Apps using embedded Javascript
 
 The following Angular apps use the embedded Javascript method of inclusion and are configured to load the header environment matching their own environment (e.g. 'QA' deployment loads 'QA' header JS, etc.):
- * [**Locations**](https://github.com/NYPL/locations-app): Locations QA is deployed with `LOCINATOR_ENV` "qa", which causes app to use qa deployments of refinery and header app (i.e. [App will load `https://qa-header.nypl.org/dgx-header.min.js?skipNav=main-content`](https://github.com/NYPL/locations-app/blob/8517c884fe8bc46998077ced735b992875a47b5a/views/index.erb#L65)
  * [**Staff Profiles**](https://github.com/NYPL/staff-profiles/blob/c1ccec275ef7754632c617821a6c1287cfb245a5/views/staff_profiles.erb#L55): Staff Profiles appears to be [configured identically](https://github.com/NYPL/staff-profiles/blob/c1ccec275ef7754632c617821a6c1287cfb245a5/views/staff_profiles.erb#L55), although [**it's unclear where/how this is deployed**](https://github.com/NYPL/staff-profiles/issues/3)
  * [**Research Divisions**](https://bitbucket.org/NYPL/research-collections): This also appears to be [configured identically](https://bitbucket.org/NYPL/research-collections/src/04d8a64e3b140a5751a78974b895c60006c97309/views/research_collections.erb?at=master#research_collections.erb-55), but it's also [**unclear where/how this is deployed**](https://bitbucket.org/NYPL/research-collections/issues/2/how-is-this-deployed).
 

--- a/other/updating-header.md
+++ b/other/updating-header.md
@@ -18,7 +18,6 @@ Starting with the lowest traffic [React apps](https://github.com/NYPL/engineerin
 
  * [Get a library card](https://github.com/NYPL/nypl-library-card-app)
  * [New Arrivals](https://github.com/NYPL/dgx-new-arrivals)
- * [Staff picks](https://github.com/NYPL/staff-picks)
  * [BookLists](https://github.com/NYPL/dgx-booklists)
  * [SCC](https://github.com/NYPL-discovery/discovery-front-end)
  * [Global Search](https://github.com/NYPL/dgx-global-search)

--- a/standards/decommissioning.md
+++ b/standards/decommissioning.md
@@ -11,6 +11,7 @@ Developer(s) MUST:
 * let the team know that an app/codebase is deprecated. A message SHOULD be sent in the #dev channel in NYPL's Slack or also email digitaldev@nypl.org.
 * update related documentation where the app/codebase's name comes up. The app's name can be searched in NYPL's Confluence wiki or by asking a teammate in Digital.
 * archive the repo on Github.
+* make sure that all the application servers are shutdown. This includes the development, qa, and production servers on AWS Elastic Beanstalk and any that NYPL IT hosts.
 
 ## Example
 

--- a/standards/decommissioning.md
+++ b/standards/decommissioning.md
@@ -10,6 +10,7 @@ Developer(s) MUST:
 * update the codebase's README. This MUST include a "Deprecaated" heading at the top and a "no longer supported" note, including the date of decommission if possible. If the repository has moved to a different source control location, the link MUST be included.
 * let the team know that an app/codebase is deprecated. A message SHOULD be sent in the #dev channel in NYPL's Slack or also email digitaldev@nypl.org.
 * update related documentation where the app/codebase's name comes up. The app's name can be searched in NYPL's Confluence wiki or by asking a teammate in Digital.
+* archive the repo on Github.
 
 ## Example
 

--- a/standards/decommissioning.md
+++ b/standards/decommissioning.md
@@ -7,6 +7,15 @@ When this happens, the developer(s) working on the new iteration of an applicati
 The above also applies to codebases that will no longer be used, such as moving code from one codebase to another, or upgrading to a different tool.
 
 Developer(s) MUST:
-* update the codebase's README with a deprecated and a no longer supported note
-* let the team know that an app/codebase is deprecated
-* update related documentation where the app/codebase's name comes up
+* update the codebase's README. This MUST include a "Deprecaated" heading at the top and a "no longer supported" note, including the date of decommission if possible. If the repository has moved to a different source control location, the link MUST be included.
+* let the team know that an app/codebase is deprecated. A message SHOULD be sent in the #dev channel in NYPL's Slack or also email digitaldev@nypl.org.
+* update related documentation where the app/codebase's name comes up. The app's name can be searched in NYPL's Confluence wiki or by asking a teammate in Digital.
+
+## Example
+
+The Staff Picks react application was recently decommissioned and moved to a Drupal-based application. The following is on the [Staff Picks README](https://github.com/nypl/staff-picks).
+
+```
+# Deprecated
+As of February 2020, this app is no longer in use at NYPL, and the current implementation is Drupal-based. Please contact the DXP/RENO team in Digital for more information. For NYPL developers, please see documentation on the update on [Confluence](https://confluence.nypl.org/pages/viewpage.action?pageId=24150584).
+```

--- a/standards/decommissioning.md
+++ b/standards/decommissioning.md
@@ -1,10 +1,10 @@
-# Deprecating Apps
+# Decommissioning and Deprecating Apps
 
 NYPL creates different applications for user interfaces, data pipeline flow, APIs, and more. While we maintain these applications, sometimes it's better to move from one platform to another for many reasons.
 
 When this happens, the developer(s) working on the new iteration of an application MUST let others know that the older version will be deprecated. This can reduce confusion on whether packages need to be updated for an app or codebase.
 
-The above also applies to codebases which will no longer be used, such as moving code from one codebase to another.
+The above also applies to codebases that will no longer be used, such as moving code from one codebase to another, or upgrading to a different tool.
 
 Developer(s) MUST:
 * update the codebase's README with a deprecated and a no longer supported note

--- a/standards/decommissioning.md
+++ b/standards/decommissioning.md
@@ -7,7 +7,7 @@ When this happens, the developer(s) working on the new iteration of an applicati
 The above also applies to codebases that will no longer be used, such as moving code from one codebase to another, or upgrading to a different tool.
 
 Developer(s) MUST:
-* update the codebase's README. This MUST include a "Deprecaated" heading at the top and a "no longer supported" note, including the date of decommission if possible. If the repository has moved to a different source control location, the link MUST be included.
+* update the codebase's README. This MUST include a "Deprecated" heading at the top and a "no longer supported" note, including the date of decommission if possible. If the repository has moved to a different source control location, the link MUST be included.
 * let the team know that an app/codebase is deprecated. A message SHOULD be sent in the #dev channel in NYPL's Slack or also email digitaldev@nypl.org.
 * update related documentation where the app/codebase's name comes up. The app's name can be searched in NYPL's Confluence wiki or by asking a teammate in Digital.
 * archive the repo on Github.


### PR DESCRIPTION
I wasn't sure where to write this so I created a new file for this under the `other` directory. Let me know if I'm missing something and should include it.

This is to cover two specific cases I recently encountered:
* I'm moving code from one codebase to another and will deprecate the original codebase.
* I received a PR for a codebase that is deprecated and I'm assuming the developer did not know that it's no longer being used.