### PR TITLE
NOREF Add TAD documentation and update RCA docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY/OPTIONAL, in these doc
   * [Python]()
   * [Ruby on Rails]() 
   * [PHP]()
+* [Technical Approach Documents](standards/technical-approach.md)
 * [Peer Review](standards/peer-review.md)
 * [CI Coverage](standards/ci.md)
   * [Github Actions]()
@@ -35,7 +36,7 @@ The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY/OPTIONAL, in these doc
   * [Node Lambda](standards/node-lambda.md)
 * [Production Readiness](standards/production-readiness.md)
 * [Monitoring & Alarms](standards/alerting.md)
-* [Post-mortems](standards/postmortems.md)
+* [Root Cause Analysis](standards/root-cause-analysis.md)
 
 #### Security
 * [General](security/README.md)

--- a/post-mortems/sample.md
+++ b/post-mortems/sample.md
@@ -1,4 +1,5 @@
-_Before running a post-mortem, please see the [post-mortem standards](../standards/postmortems.md)._
+
+NOTE: This sample post-mortem pre-dates the use of [Root Cause Analysis](../standards/root-cause-analysis.md). Please use this for reference only and create a RCA if you are documenting a recent outage.
 
 # Sample Post-mortem
 

--- a/standards/root-cause-analysis.md
+++ b/standards/root-cause-analysis.md
@@ -6,9 +6,11 @@ The root cause analysis SHOULD be done as soon as possible _after_ the incident 
 
 RCAs are *blameless*. We're all human and make mistakes. At NYPL we want to encourage an [engineering culture](../culture/values.md#not-shaming-or-blaming) of experimentation, learning, continuous improvement, and making room for mistakes.
 
-Completed RCAs SHOULD be saved in Confluence, under the space for your project. This is a directory for a historical record and shared with relevant parties.
+RCAs SHOULD be saved in a shared directory where they are accessible by other team members.
 
-### More learning about post-mortems ###
+RCAs MUST be shared with the revelant Product Manager for approval and sent to Garvita Kapur for review after approval within the team.
+
+### More learning about RCAs ###
 
 - [Google SRE - Postmortem Culture: Learning from Failure](https://landing.google.com/sre/book/chapters/postmortem-culture.html)
 - [How to Write Great Outage Post-Mortems](http://artsy.github.io/blog/2014/11/19/how-to-write-great-outage-post-mortems/)
@@ -17,7 +19,11 @@ Completed RCAs SHOULD be saved in Confluence, under the space for your project. 
 
 ## Sample RCA Template
 
-Here is the information that SHOULD be included in a post-mortem. The complexity and length of each answer MAY be determined by the severity of the incident.
+Here is the information that SHOULD be included in a RCA. The complexity and length of each answer MAY be determined by the severity of the incident. Each RCA MUST include:
+
+- A timeline of the event
+- The completion of an analysis of the causes of the event
+- A proposed solution/resolution that addresses the issue in a way that should prevent reoccurence in the future
 
 [Sample post-mortem template](https://docs.google.com/spreadsheets/d/1lrOpMoxWKXduwgbEjfASfhcP0l3D99V3vQ853wzWJ9I/edit?usp=sharing)
 

--- a/standards/technical-approach.md
+++ b/standards/technical-approach.md
@@ -30,9 +30,17 @@ All TADs MUST follow this process to be approved, at which point JIRA tickets ca
 2. The assigned developer should collect as much information from the BRD, stakeholders and any other relevant information sources and write the TAD
 3. The TAD MAY be circulated at this point for feedback within a team or stakeholders for further input/feedback
 4. When ready for review the Engineering Leadership Team (ELT) should be notified and the TAD uploaded to the shared TAD Google Drive (see below)
-5. The TAD MUST be reviewed by at least one ELT member with subject area knowledge, and SHOULD be reviewed by two members
+5. The TAD MUST be reviewed by at least one ELT member with subject area knowledge, and SHOULD be reviewed by two members (see review process below)
 6. If approved in Step 5 the TAD should be sent to Garvita Kapur for final approval
 7. If approved specific tickets should be created to execute the work as described in the TAD
+
+### Review Process
+
+Step 5 above includes the following steps to be followed by the Tech Lead/Architect who is reviewing the document:
+
+1. After reviewing the document they should add a summary to the end of the TAD including: Potential Risk, Cost and an evaluation of the completion of the TAD
+2. If revisions are requested/necessary the document's author should make the necessary changes and record the process in a changelog to be added to the end of the document
+3. The above steps should be repeated until the document is approved
 
 ## Resources
 

--- a/standards/technical-approach.md
+++ b/standards/technical-approach.md
@@ -1,0 +1,29 @@
+# Technical Approach Documents
+
+Technical Approach Documents (TADs) serve to help the engineering team document solutions to feature development, share ideas between teams and help highlight potential issues with tasks before they are encountered during the development process.
+
+TADs should strive to describe the whats, hows and whys of the technical problem that is trying to be solved. It should strive to understand the problem at hand in a comprehensive way and explore any challenges so that engineers can be confident in their implementations of solutions. In short writing a TAD should answer any technical questions prior to the start of actual development work, freeing up developers to focus on implementation once the major questions have been resolved.
+
+## Process
+
+TADs do not have to be created for all development work, but MUST be created in the following cases:
+
+- If a Business Requirements Document (BRD) has been created
+- If the scope of work is expected to extend beyond a single sprint
+- If multiple developers will be contributing to the new feature
+
+All TADs MUST follow this process to be approved, at which point JIRA tickets can be created and development work can start.
+
+1. The most senior developer on the feature/task/story is assigned a ticket to write the TAD and the ticket MUST be tagged with `tech-approach`
+2. The assigned developer should collect as much information from the BRD, stakeholders and any other relevant information sources and write the TAD
+3. The TAD MAY be circulated at this point for feedback within a team or stakeholders for further input/feedback
+4. When ready for review the Engineering Leadership Team (ELT) should be notifed and the TAD uploaded to the shared TAD Google Drive (see below)
+5. The TAD MUST be reviewed by at least one ELT member with subject area knowledge, and SHOULD be reviewed by two members
+6. If approved in Step 5 the TAD should be sent to Garvita Kapur for final approval
+7. If approved specific tickets should be created to execute the work as described in the TAD
+
+## Resources
+
+- [Shared TAD Google Drive](https://drive.google.com/drive/u/0/folders/0AN2RNnk4RBBwUk9PVA): All TADs should be added to this drive in the appropraiate portfolio group's directory
+- [TAD Reference Doc](https://docs.google.com/document/d/1jL7yxFBmb8Pv9VR-dYNX1VTFaJzIgfVRyzinKk-T200/edit?usp=sharing): A sample TAD document to be used as the basis for future documents
+- [Confluence TAD Documentation](https://confluence.nypl.org/display/DIGTL/Technical+Approach+Documents): Similar documentation page in confluence containing list of sample TADs from different projects

--- a/standards/technical-approach.md
+++ b/standards/technical-approach.md
@@ -20,7 +20,8 @@ TADs do not have to be created for all development work, but MUST be created in 
 TADs SHOULD be created in the following situations:
 
 - If multiple approaches to a feature or problem are valid and the engineer assigned the ticket(s) wishes to document the decisions made
-- If questions are raised about the appropriateness of an approach and engineer/team wishes to document the decision process 
+- If questions are raised about the appropriateness of an approach and engineer/team wishes to document the decision process
+- If a engineer is faced with a decision or choice that they would like to receive feedback on and/or have validated by a more senior member of the engineering team
 
 ## Process
 
@@ -29,9 +30,9 @@ All TADs MUST follow this process to be approved, at which point JIRA tickets ca
 1. The most senior developer on the feature/task/story is assigned a ticket to write the TAD and the ticket MUST be tagged with `tech-approach`
 2. The assigned developer should collect as much information from the BRD, stakeholders and any other relevant information sources and write the TAD
 3. The TAD MAY be circulated at this point for feedback within a team or stakeholders for further input/feedback
-4. When ready for review the Engineering Leadership Team (ELT) should be notified and the TAD uploaded to the shared TAD Google Drive (see below)
+4. When ready for review the Engineering Leadership Team (ELT) should be notified, the TAD uploaded to the shared TAD Google Drive (see below), and the associated JIRA ticket moved to the `Under Review` column
 5. The TAD MUST be reviewed by at least one ELT member with subject area knowledge, and SHOULD be reviewed by two members (see review process below)
-6. If approved in Step 5 the TAD should be sent to Garvita Kapur for final approval
+6. If approved in Step 5 the TAD should be sent to Garvita Kapur for final approval. With final approval the associated JIRA ticket is moved to `Done`
 7. If approved specific tickets should be created to execute the work as described in the TAD
 
 ### Review Process

--- a/standards/technical-approach.md
+++ b/standards/technical-approach.md
@@ -4,26 +4,38 @@ Technical Approach Documents (TADs) serve to help the engineering team document 
 
 TADs should strive to describe the whats, hows and whys of the technical problem that is trying to be solved. It should strive to understand the problem at hand in a comprehensive way and explore any challenges so that engineers can be confident in their implementations of solutions. In short writing a TAD should answer any technical questions prior to the start of actual development work, freeing up developers to focus on implementation once the major questions have been resolved.
 
-## Process
+## Authors
+
+TADs should be written by the most senior engineer who is or will be working on a project/feature/fix. If it is unknown who will be doing the implementation work for a project an engineer with previous experience or subject matter knowledge should be assigned the task of writing a TAD.
+
+## When Necessary
 
 TADs do not have to be created for all development work, but MUST be created in the following cases:
 
 - If a Business Requirements Document (BRD) has been created
 - If the scope of work is expected to extend beyond a single sprint
 - If multiple developers will be contributing to the new feature
+- If the pros and cons of introducing a new tool or technology to a project, team, or the department need to be considered
+
+TADs SHOULD be created in the following situations:
+
+- If multiple approaches to a feature or problem are valid and the engineer assigned the ticket(s) wishes to document the decisions made
+- If questions are raised about the appropriateness of an approach and engineer/team wishes to document the decision process 
+
+## Process
 
 All TADs MUST follow this process to be approved, at which point JIRA tickets can be created and development work can start.
 
 1. The most senior developer on the feature/task/story is assigned a ticket to write the TAD and the ticket MUST be tagged with `tech-approach`
 2. The assigned developer should collect as much information from the BRD, stakeholders and any other relevant information sources and write the TAD
 3. The TAD MAY be circulated at this point for feedback within a team or stakeholders for further input/feedback
-4. When ready for review the Engineering Leadership Team (ELT) should be notifed and the TAD uploaded to the shared TAD Google Drive (see below)
+4. When ready for review the Engineering Leadership Team (ELT) should be notified and the TAD uploaded to the shared TAD Google Drive (see below)
 5. The TAD MUST be reviewed by at least one ELT member with subject area knowledge, and SHOULD be reviewed by two members
 6. If approved in Step 5 the TAD should be sent to Garvita Kapur for final approval
 7. If approved specific tickets should be created to execute the work as described in the TAD
 
 ## Resources
 
-- [Shared TAD Google Drive](https://drive.google.com/drive/u/0/folders/0AN2RNnk4RBBwUk9PVA): All TADs should be added to this drive in the appropraiate portfolio group's directory
+- [Shared TAD Google Drive](https://drive.google.com/drive/u/0/folders/0AN2RNnk4RBBwUk9PVA): All TADs should be added to this drive in the appropriate portfolio group's directory
 - [TAD Reference Doc](https://docs.google.com/document/d/1jL7yxFBmb8Pv9VR-dYNX1VTFaJzIgfVRyzinKk-T200/edit?usp=sharing): A sample TAD document to be used as the basis for future documents
 - [Confluence TAD Documentation](https://confluence.nypl.org/display/DIGTL/Technical+Approach+Documents): Similar documentation page in confluence containing list of sample TADs from different projects


### PR DESCRIPTION
This adds the creation of TADs to the engineering best practices documentation, as this is something that is being required for new work. It also updates the RCA documentation to be sure that the transition from post-mortems to RCA is currently in place and that post-mortems should not be created. It also removes a reference to a non-existent shared drive for RCAs.