### PR TITLE
Document the integration between GitHub Actions and Slack 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY/OPTIONAL, in these doc
 * [Technical Approach Documents](standards/technical-approach.md)
 * [Peer Review](standards/peer-review.md)
 * [CI Coverage](standards/ci.md)
-  * [Github Actions]()
+  * [Github Actions](standards/github-actions.md)
   * [Travis CI](standards/travis-ci.md) 
 * [Deployment](standards/deployment.md)
   * [AWS](standards/aws.md)

--- a/standards/ci.md
+++ b/standards/ci.md
@@ -16,7 +16,7 @@ In order to ensure that the new code changes have not broken the behavior of the
 3) When the build is red, the top priority of the team is to fix the build.
 A red build means the last change possibly did not integrate with the existing code. All further check-ins that are not related to fix the build must be stopped and the goal has to be to get the build passing again.
 
-**Single Repo For Each Service And Corresponsing CI Build**  
+**Single Repo For Each Service And Corresponding CI Build**
   Every microservice SHOULD have its own independent source code repo and its corresponding CI build. The following configurations are discouraged:
   - having a single repo for multiple services with separate CI builds
   - having a single repo for multiple services and having one CI build for all the services
@@ -24,3 +24,8 @@ A red build means the last change possibly did not integrate with the existing c
 **Example Usage - Travis Configuration**  
 * [Travis CI](./travis-ci.md)
 
+**Communicating CI status to Slack**
+
+We use the [NYPL Test Result Reporter](https://api.slack.com/apps/A02EA1SPS21/) Slack app to manage communications between CI processes and Slack. Any CI process that runs tests SHOULD report failures to the #test-reports channel, and MAY report both success and failure to that channel.
+
+An admin of the NYPL Test Result Reporter app can tell you the WebHook URL to use for this.

--- a/standards/github-actions.md
+++ b/standards/github-actions.md
@@ -1,0 +1,17 @@
+## Reporting results to Slack
+
+We use the [action-slack-notify](https://github.com/rtCamp/action-slack-notify) Github Action to post the results of GitHub actions to Slack. Here's an example configuration from the [circulation-patron-web](https://github.com/NYPL-Simplified/circulation-patron-web/) project, which posts a link to a report from an integration test suite:
+
+```
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env: 
+          SLACK_CHANNEL: test_reports
+          SLACK_MESSAGE: ${{ steps.cypress.outputs.dashboardUrl }}
+          SLACK_TITLE: Circulation Patron Web End-to-End Cypress Test Results
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: nyplorgBot
+```
+
+In this case, the `SLACK_WEBHOOK` secret is set to the (test report WebHook URL)[ci.md].
+

--- a/standards/github-actions.md
+++ b/standards/github-actions.md
@@ -13,5 +13,5 @@ We use the [action-slack-notify](https://github.com/rtCamp/action-slack-notify) 
           SLACK_USERNAME: nyplorgBot
 ```
 
-In this case, the `SLACK_WEBHOOK` secret is set to the (test report WebHook URL)[ci.md].
+In this case, the `SLACK_WEBHOOK` secret is set to the [test report WebHook URL](ci.md).
 


### PR DESCRIPTION
This branch adds some documentation about configuring GitHub Actions to report test results to Slack. I started a new document for GitHub Actions since this is the first time we're really talking about them here, but there's clearly a lot more that could go into that document.