### PR TITLE
PR Review Best Practices

### DIFF
--- a/standards/peer-review.md
+++ b/standards/peer-review.md
@@ -1,7 +1,9 @@
 ## Pull Request Workflow
 
-All Pull Requests to NYPL repositories SHOULD be reviewed prior to merging.
-
+- All Pull Requests to NYPL repositories MUST be reviewed prior to merging (caveat below).
+  - PRs MUST NOT be merged if a reviewed requests changes
+  - Teams MAY agree to specific written policies as to conditions when reviews are not required. Such a policy MUST be approved by a Tech Lead or Engineering Manager.
+  
 - Engineers MUST mark at least one (1) developer as a reviewer and SHOULD request reviews from all relevant engineers
   - Reviewers MAY come from any team within NYPL Digital
   - Teams MAY create [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) files to establish a default group of reviewers
@@ -11,11 +13,8 @@ All Pull Requests to NYPL repositories SHOULD be reviewed prior to merging.
 - Engineers marked as reviewers SHOULD complete the review in a timely manner
   - This period SHOULD be agreed upon within individual development teams, 24-48 hours has proven to be a reasonable starting place
   - Code review SHOULD take some time (more than a quick LGTM) but should not take more than 1-2 hours
-  - If a code review is very lengthy or complex, reviewers MAY request that the PR be broken up into smaller pieces
+  - If a code review is very lengthy or complex, reviewers MAY request that the PR be broken up into smaller pieces and/or request a walkthrough/live review session
  
-- Pull requests SHOULD NOT be merged without a review and MUST not be merged if a reviewer requests changes
-  - Specific policies MAY be agreed upon within teams as to when reviews are required or optional
-
 - If changes are requested (or made in response to questions) the requesting engineer SHOULD re-request review when ready
   - This helps reviewers track the current status of open PRs and plan time for review work
   - Additional rounds of review SHOULD be completed until the PR can be either merged or closed

--- a/standards/peer-review.md
+++ b/standards/peer-review.md
@@ -1,3 +1,26 @@
+## Pull Request Workflow
+
+All Pull Requests to NYPL repositories SHOULD be reviewed prior to merging.
+
+- Engineers MUST mark at least one (1) developer as a reviewer and SHOULD request reviews from all relevant engineers
+  - Reviewers MAY come from any team within NYPL Digital
+  - Teams MAY create [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) files to establish a default group of reviewers
+  - Experience SHOULD not be taken into account when requesting review
+  - Requests for specific feedback MAY be requested by tagging specific engineers in PR comments
+
+- Engineers marked as reviewers SHOULD complete the review in a timely manner
+  - This period SHOULD be agreed upon within individual development teams, 24-48 hours has proven to be a reasonable starting place
+  - Code review SHOULD take some time (more than a quick LGTM) but should not take more than 1-2 hours
+  - If a code review is very lengthy or complex, reviewers MAY request that the PR be broken up into smaller pieces
+ 
+- Pull requests SHOULD NOT be merged without a review and MUST not be merged if a reviewer requests changes
+  - Specific policies MAY be agreed upon within teams as to when reviews are required or optional
+  - 
+
+- If changes are requested (or made in response to questions) the requesting engineer SHOULD re-request review when ready
+  - This helps reviewers track the current status of open PRs and plan time for review work
+  - Additional rounds of review SHOULD be completed until the PR can be either merged or closed
+
 # Peer Review
 
 - All peer review MUST comply with our [Engineering Values](../culture/values.md)
@@ -13,14 +36,3 @@
 - It MAY involve a team member who is less experienced with the tech stack.
 
   - Example: A team member who is familiar with PHP can sit down with a team member familiar with Ruby on Rails, walking through the idea behind the PHP code, followed by a list concrete tests showing the code works.
-
-## Pull Request Workflow
-
-A common type of peer review involves two or more developers reviewing a pull request from a code repository.
-
-- Developers when submitting pull request, SHOULD mark at least one (1) developer as reviewer.
-
-- Reviewers receiving pull request SHOULD accept the invitation and SHOULD review the code.
-
-- If reviewers do not respond to a review request by the 3rd business day, the author SHOULD follow up with a request for an in-person review.  Project teams MAY establish a rhythm to increase predictability.
-  - Examples: "aim for a 4-hour turn-around", "review must be complete by 10am the next business day", or "send a Slack reminder for people who prefer").

--- a/standards/peer-review.md
+++ b/standards/peer-review.md
@@ -19,6 +19,10 @@
   - This helps reviewers track the current status of open PRs and plan time for review work
   - Additional rounds of review SHOULD be completed until the PR can be either merged or closed
 
+- Engineers SHOULD utilize the Draft PR status to socialize work in progress and to solicit feedback
+  - Reviewers SHOULD NOT use the "request changes" option on draft PR reviews
+  - When a draft PR is ready for full review the requesting engineer MUST update its status and request (or re-request) review from relevant team members
+
 # Peer Review
 
 - All peer review MUST comply with our [Engineering Values](../culture/values.md)

--- a/standards/peer-review.md
+++ b/standards/peer-review.md
@@ -18,6 +18,7 @@
 - If changes are requested (or made in response to questions) the requesting engineer SHOULD re-request review when ready
   - This helps reviewers track the current status of open PRs and plan time for review work
   - Additional rounds of review SHOULD be completed until the PR can be either merged or closed
+  - To help track PR status teams MAY use GitHub labels (e.g. `Changes Requested`, `Needs Review` and `Ship It`) to help socialize status.
 
 - Engineers SHOULD utilize the Draft PR status to socialize work in progress and to solicit feedback
   - Reviewers SHOULD NOT use the "request changes" option on draft PR reviews

--- a/standards/peer-review.md
+++ b/standards/peer-review.md
@@ -1,8 +1,8 @@
 ## Pull Request Workflow
 
 - All Pull Requests to NYPL repositories MUST be reviewed prior to merging (caveat below).
-  - PRs MUST NOT be merged if a reviewed requests changes
-  - Teams MAY agree to specific written policies as to conditions when reviews are not required. Such a policy MUST be approved by a Tech Lead or Engineering Manager.
+  - PRs MUST NOT be merged if a reviewer requests changes
+  - Teams MAY agree to specific written policies as to conditions when reviews are not required. Such a policy MUST be approved by an Engineering Manager or Director.
   
 - Engineers MUST mark at least one (1) developer as a reviewer and SHOULD request reviews from all relevant engineers
   - Reviewers MAY come from any team within NYPL Digital

--- a/standards/peer-review.md
+++ b/standards/peer-review.md
@@ -5,7 +5,7 @@ All Pull Requests to NYPL repositories SHOULD be reviewed prior to merging.
 - Engineers MUST mark at least one (1) developer as a reviewer and SHOULD request reviews from all relevant engineers
   - Reviewers MAY come from any team within NYPL Digital
   - Teams MAY create [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) files to establish a default group of reviewers
-  - Experience SHOULD not be taken into account when requesting review
+  - Experience SHOULD NOT be taken into account when requesting review
   - Requests for specific feedback MAY be requested by tagging specific engineers in PR comments
 
 - Engineers marked as reviewers SHOULD complete the review in a timely manner

--- a/standards/peer-review.md
+++ b/standards/peer-review.md
@@ -15,7 +15,6 @@ All Pull Requests to NYPL repositories SHOULD be reviewed prior to merging.
  
 - Pull requests SHOULD NOT be merged without a review and MUST not be merged if a reviewer requests changes
   - Specific policies MAY be agreed upon within teams as to when reviews are required or optional
-  - 
 
 - If changes are requested (or made in response to questions) the requesting engineer SHOULD re-request review when ready
   - This helps reviewers track the current status of open PRs and plan time for review work
@@ -25,7 +24,7 @@ All Pull Requests to NYPL repositories SHOULD be reviewed prior to merging.
 
 - All peer review MUST comply with our [Engineering Values](../culture/values.md)
 
-- All work SHOULD go through the process of peer review. It is a form of collaboration and it strengthens  quality.
+- All work SHOULD go through the process of peer review. It is a form of collaboration and it strengthens quality.
 
 - It SHOULD involve at least one (1) more experienced developer evaluating whether best practices are followed.
 


### PR DESCRIPTION
This PR updates our page on PR review best practices. This page hasn't been touched in 5+ years so this includes both a general update as well as the addition of a few things:

- Added recommendation to use a `CODEOWNERS` file to help encourage a practice of tagging all team members in PRs
- Added general recommendation for timing and length of PR review processes
- Added recommendation to re-tag reviewers after updating a PR based on feedback to bump it back up in peoples' inboxes
- Generally reformatted

Please provide any feedback or additional best practices that you'd like to see added!