### PR TITLE
Onboarding Re-Write

### DIFF
--- a/on-off-board/offboarding.md
+++ b/on-off-board/offboarding.md
@@ -4,15 +4,11 @@ It's so hard to say goodbye but sometimes we must at NYPL.
 
 ## Remove Accounts
 
-Remove the [accounts](onboarding.md#2-set-up-accounts) that might have been created during the onboarding process.
+Remove the [accounts](onboarding.md#2-account-setup) that might have been created during the onboarding process.
 
-Remove the user from the [NYPL GitHub Organization](https://github.com/orgs/NYPL/people).
+Remove the user from the [NYPL GitHub Organization](https://github.com/orgs/NYPL/people) and all teams that they have been added to.
 
 ### Slack
 
 1.  Convert the user to a guest in the `#general` channel.
 2.  Set the user to be deactivated in 3 months. (In the Slack administrative interface)
-
-## Remove Keys
-
-Remove the [public key](onboarding.md#3-set-up-keys) added during the onboarding process.

--- a/on-off-board/onboarding.md
+++ b/on-off-board/onboarding.md
@@ -4,77 +4,96 @@ Welcome to NYPL Digital!
 
 This document is intended to help developers become familiar with NYPL digital properties and standards.
 
-## 1. Learn
+## Welcome & First Day
 
-- Review the [Contents](../README.md#contents) in the `engineering-general` repo.
-  - Contains links to development standards and guidelines at NYPL.
-- Review READMEs (or Wikis) in relevant repos
-  - Generally, each repo will contain more app-specific information.
+We hope that you'll have a good first at NYPL Digital! Generally 4 things should happen your first day:
 
-## 2. Set up accounts
+1. You'll meet your team and have a lunch or other meet-and-greet
+2. You'll get your laptop and have some time to set it up
+3. You'll be given an onboarding packet that lays out your first day, week, month and quarter
+4. You'll start meeting with your team members and collaborators to start planning your work
+
+After that your intro will vary depending on your team and role, but it should focus at least in these areas
+
+## 1. Learning
+
+There is a lot to learn in Digital, and there is no way to pick everything up in your first month, let alone your first day! So here are some tips for starting the process of learning the whats, wheres, hows and whys of our department.
+
+- Review the [Contents](../README.md#contents) of this repo.
+- Review READMEs (or Wikis) of the repositories your team maintains
+  - Your manager and onboarding buddy should help give you context for them
+  - A good approach is to spin up local dev environments for any repositories you'll be contributing to.
+- Set up meetings with other engineers on your team to get a sense for the status of the team's work and where you can help contribute!
+- Review the documents and initial tasks outlined in the specific onboarding documents provided to you on your first day (Which is probably how you ended up here!)
+- Ask questions. If your manager did not ask you to do this already: start a document with questions and things that were unclear!
+  - This document should be an important part of your early 1:1s with your manager
+  - We want to use these questions to improve our documentation and processes! People with fresh eyes often see things that we miss
+
+## 2. Account Setup
+
+### Password Management
+
+We __strongly__ encourage team members to use a password manager for their credentials. There will be many passwords you need to track and the dangers of password reuse are real. We recommend one of the following password management tools:
+
+- [Keeper](https://keepersecurity.com)
+  - This is NYPL's approved password manager
+  - To create a keeper account attempt to sign in with your `@nypl.org` email address, you should be prompted to request Admin approval.
+- [MacPass](https://macpassapp.org/)
+  - This is a local, open source, password management solution
+  - It is not officially supported, but provides an easy place to track passwords
 
 ### Commonly used accounts
 
-A developer will generally need accounts for the following services:
+A developer will generally need accounts for the following services. Most of these accounts will be configured for you during onboarding, please request access for any systems you do not have access to.
 
-- Slack
-  - [nypl.slack.com](https://nypl.slack.com/)
+- [Slack](https://nypl.slack.com/) Preferred method of communication
 - GitHub (Can use a personal account or make a new NYPL specific GitHub account)
-
-  - NYPL GitHub organization:
-
-    - [NYPL](https://github.com/NYPL)
-    - See [GitHub Organization Management](./github-org-management.md) for onboarding steps.
-
-  - Old and no-longer used organizations
+  - [NYPL Main GitHub Organization](https://github.com/NYPL)
+  - See [GitHub Organization Management](./github-org-management.md) for onboarding steps.
+  - Team-specific organizations
+    - [NYPL-discovery](https://github.com/NYPL-discovery)
+    - [NYPL-Simplified](https://github.com/NYPL-Simplified)
+  - Old and/or unused organizations
     - [NYPL-registry](https://github.com/NYPL-registry)
     - [nypl-spacetime](https://github.com/nypl-spacetime)
     - [nypl-open-audio](https://github.com/nypl-openaudio)
     - [nypl-publicdomain](https://github.com/NYPL-publicdomain)
-    - [NYPL-discovery](https://github.com/NYPL-discovery)
-    - [NYPL-Simplified](https://github.com/NYPL-Simplified)
-
-- JIRA\*
-  - [jira.nypl.org](https://jira.nypl.org/)
-- [Docker Hub](https://hub.docker.com/u/nypl/)
-- Amazon Web Services (AWS)
-  - Primary AWS accounts (MFA Login):
-    - [nypl-digital-dev](https://nypl-digital-dev.signin.aws.amazon.com/console)
-- Bamboo\*: Deployment happens via Bamboo
-  - [http://bamboo.nypl.org/](http://bamboo.nypl.org/)
+- [JIRA](https://jira.nypl.org/) Ticket Management & Tracking
+- Amazon Web Services (AWS) Accounts (MFA login required)
+  - [nypl](https://nypl.signin.aws.amazon.com/console) Main production account
+  - [nypl-dev](https://nypl-dev.signin.aws.amazon.com/console) Main QA/dev account
+  - [nypl-digital-dev](https://nypl-digital-dev.signin.aws.amazon.com/console) Main account for LSP and DRB
+  - [nypl-sandbox](https://nypl-sandbox.signin.aws.amazon.com/console) Dev/testing environment
+  - [nypl-labs](https://nypl-labs.signin.aws.amazon.com/console) Hosting old projects
+  - Other accounts are in use by different teams. Speak with team leadership for details
 
 ### Less commonly used accounts
 
-- NYPL Platform
-  - [https://platform.nypl.org](https://platform.nypl.org)
-- [npm organization](https://www.npmjs.com/org/nypl): You do not need an npm account to publish to npm
-- [Stash](https://stash.nypl.org/): (NYPL VPN needed) IT and devops keep AWS configurations, among other things, here.
-- [Travis CI](https://travis-ci.com): Accounts are OAuthed and synced through GitHub. Adding/Removing access to GitHub controls access to Travis.
-- Bitbucket: Older apps are on bitbucket
-  - [bitbucket.org/NYPL](https://bitbucket.org/NYPL)
-- Loggly
-  - [https://nypl.loggly.com](https://nypl.loggly.com)
-- CI Servers (e.g Jenkins instances)
-  - [https://ci-sa.prod.aws.nypl.org](https://ci-sa.prod.aws.nypl.org)
-- Optimizely
-  - [https://app.optimizely.com](https://app.optimizely.com)
-- Google Analytics
-  - [https://analytics.google.com](https://analytics.google.com)
-- Amazon Web Services (AWS)
-  - Secondary AWS accounts (MFA Login):
-    - [nypl-sandbox](https://nypl-sandbox.signin.aws.amazon.com/console)
-    - [nypl/prod](https://nypl.signin.aws.amazon.com/console)
-    - [nypl-dev](https://nypl-dev.signin.aws.amazon.com/console)
-    - [nypl-labs](https://nypl-labs.signin.aws.amazon.com/console)
-- Data Warehouse DB credential
-  - [https://github.com/NYPL/data-warehouse#users](https://github.com/NYPL/data-warehouse#users)
-- [New Relic](https://newrelic.com/) (Not currently used, just legacy for off-boarding)
+- [NYPL Platform](https://platform.nypl.org) Assorted APIs for interacting with NYPL resources
+- [NPM Organization](https://www.npmjs.com/org/nypl) (NOTE: You do not need an npm account to publish to npm)
+- [New Relic](https://newrelic.com/) Telemetry, metrics and monitoring
+- [Docker Hub](https://hub.docker.com/u/nypl/) Used for publically distributed images. Internal images are hosted on AWS ECR
+- Analytics
+  - [Adobe Analytics](https://experience.adobe.com) NYPL's main analytics solution
+  - [Google Analytics](https://analytics.google.com) Largely deprecated in favor of AA, with specific exceptions 
+- Repository Management
+  - [Stash](https://stash.nypl.org/) (NYPL VPN needed) IT and devops keep AWS configurations, among other things, here.
+  - [Bitbucket](https://bitbucket.org/NYPL) Host for older git repositories
+- CI/CD
+  - [TravisCI](https://travis-ci.com) Used for some CI/CD Pipelines, largely deprecated in favor of GitHub Actions
+  - [Bamboo](http://bamboo.nypl.org/) Used for some CI/CD workflows, largely deprecated in favor of GitHub Actions
+- [Loggly](https://nypl.loggly.com) Largely deprecated in favor of NewRelic and AWS CloudWatch
 
-_\* uses [NYPL/ServiceNow](https://nyplprod.service-now.com) credentials for authentication_
+## 3. Initial Meetings
 
-## 3. Set up keys
+Your manager should set up an initial set of meetings with both team members and other Digital members you will be working with. If, at the end of your first or second week, some of these meetings haven't happened, you should reach out and schedule them! Or ask your manager to do so. You should at least have met with these people:
 
-- Having public key added/removed to appropriate `.authorized_keys` files on machines
-  - If ensuring provisioning scripts that contain this key are updated / run
-- Add user's public key to [NYPL/public_keys](https://github.com/NYPL/public_keys)
-  - See that repo's README for offboarding instructions
+- Your Manager
+- Your Project Manager
+- Your Product Manager
+- Various members of your engineering team
+- Key stakeholders and non-Digital NYPL staff (if applicable)
+
+## 4. Initial Tasks
+
+We strive to design an initial set of tickets/tasks for new team members that both allow them to begin exploring codebases tktk

--- a/on-off-board/onboarding.md
+++ b/on-off-board/onboarding.md
@@ -6,7 +6,7 @@ This document is intended to help developers become familiar with NYPL digital p
 
 ## Welcome & First Day
 
-We hope that you'll have a good first at NYPL Digital! Generally 4 things should happen your first day:
+We hope that you'll have a good first day at NYPL Digital! Generally 4 things should happen your first day:
 
 1. You'll meet your team and have a lunch or other meet-and-greet
 2. You'll get your laptop and have some time to set it up
@@ -41,6 +41,13 @@ We __strongly__ encourage team members to use a password manager for their crede
 - [MacPass](https://macpassapp.org/)
   - This is a local, open source, password management solution
   - It is not officially supported, but provides an easy place to track passwords
+
+### Multi-Factor Authentication
+
+Using multi-factor authentication (MFA) is also __strongly__ encouraged at NYPL. For some accounts (most importantly AWS) it is __required__. There are several options for MFA:
+
+- NYPL-supplied Yubi key. If you'd prefer a physical authentication key, please request one from your manager.
+- MFA Application such as Duo or Microsoft Authenticator. These should be installed on your phone to support authentication.
 
 ### Commonly used accounts
 
@@ -97,4 +104,16 @@ Your manager should set up an initial set of meetings with both team members and
 
 ## 4. Initial Tasks
 
-We strive to design an initial set of tickets/tasks for new team members that both allow them to begin exploring codebases tktk
+We strive to design an initial set of tickets/tasks for new team members that both allow them to begin exploring codebases as well as making impactful contributions early in their time in Digital. We are not a "deploy to production on Day 1" shop, but aim to have new engineers putting up PRs by the end of their first sprint.
+
+Please discuss your initial set of tasks with your manager and new team. Our goals generally are:
+
+- Allow you to explore the codebases you'll be contributing to, via tasks such as:
+  - Extending unit test coverage
+  - Refactoring a specific class/module to align with a larger codebase
+  - Implementing a new linting, CI/CD or other quality-of-life tool
+- Help you understand our standards for development in NYPL Digital, through things like:
+  - Reviewing open PRs
+  - Implementing specific code quality changes on a small codebase
+  - Refactoring an application to a new version of its current tech stack
+- Anything that you and your tech lead decide!

--- a/on-off-board/onboarding.md
+++ b/on-off-board/onboarding.md
@@ -27,7 +27,7 @@ There is a lot to learn in Digital, and there is no way to pick everything up in
 - Review the documents and initial tasks outlined in the specific onboarding documents provided to you on your first day (Which is probably how you ended up here!)
 - Ask questions. If your manager did not ask you to do this already: start a document with questions and things that were unclear!
   - This document should be an important part of your early 1:1s with your manager
-  - We want to use these questions to improve our documentation and processes! People with fresh eyes often see things that we miss
+  - We want to use these questions to improve our documentation and processes! Fresh eyes often see things that we miss
 
 ## 2. Account Setup
 
@@ -50,6 +50,7 @@ A developer will generally need accounts for the following services. Most of the
 - GitHub (Can use a personal account or make a new NYPL specific GitHub account)
   - [NYPL Main GitHub Organization](https://github.com/NYPL)
   - See [GitHub Organization Management](./github-org-management.md) for onboarding steps.
+  - We ask that all members have a username that contains their name somewhere. If you do not want to update your personal Github account, we encourage you to make an NYPL-specific account!
   - Team-specific organizations
     - [NYPL-discovery](https://github.com/NYPL-discovery)
     - [NYPL-Simplified](https://github.com/NYPL-Simplified)
@@ -69,7 +70,7 @@ A developer will generally need accounts for the following services. Most of the
 
 ### Less commonly used accounts
 
-- [NYPL Platform](https://platform.nypl.org) Assorted APIs for interacting with NYPL resources
+- [NYPL Platform](https://platformdocs.nypl.org) Assorted APIs for interacting with NYPL resources
 - [NPM Organization](https://www.npmjs.com/org/nypl) (NOTE: You do not need an npm account to publish to npm)
 - [New Relic](https://newrelic.com/) Telemetry, metrics and monitoring
 - [Docker Hub](https://hub.docker.com/u/nypl/) Used for publically distributed images. Internal images are hosted on AWS ECR


### PR DESCRIPTION
Our onboarding documentation was out of date and focused largely on adding people to accounts. This is misleading and neglects to mention the main goal of our _actual_ onboarding process: To welcome people to the team!

This rewrite attempts to center that more and update the account list to better reflect what is used and important in NYPL Digital (e.g. Less Jenkins, More GitHub)