### PR TITLE
Update peer review page based on drafted guidelines

### DIFF
--- a/standards/peer-review.md
+++ b/standards/peer-review.md
@@ -1,41 +1,38 @@
-## Pull Request Workflow
+## PR Review Guidelines & Best Practices
 
-- All Pull Requests to NYPL repositories MUST be reviewed prior to merging (caveat below).
-  - PRs MUST NOT be merged if a reviewer requests changes
-  - Teams MAY agree to specific written policies as to conditions when reviews are not required. Such a policy MUST be approved by an Engineering Manager or Director.
-  
-- Engineers MUST mark at least one (1) developer as a reviewer and SHOULD request reviews from all relevant engineers
-  - Reviewers MAY come from any team within NYPL Digital
-  - Teams MAY create [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) files to establish a default group of reviewers
-  - Experience SHOULD NOT be taken into account when requesting review
-  - Requests for specific feedback MAY be requested by tagging specific engineers in PR comments
+These guidelines establish the principles and processes for Pull Request (PR) reviews. Following them ensures we maintain high code quality, share knowledge effectively, and foster a collaborative and supportive engineering culture.
 
-- Engineers marked as reviewers SHOULD complete the review in a timely manner
-  - This period SHOULD be agreed upon within individual development teams, 24-48 hours has proven to be a reasonable starting place
-  - Code review SHOULD take some time (more than a quick LGTM) but should not take more than 1-2 hours
-  - If a code review is very lengthy or complex, reviewers MAY request that the PR be broken up into smaller pieces and/or request a walkthrough/live review session
- 
-- If changes are requested (or made in response to questions) the requesting engineer SHOULD re-request review when ready
-  - This helps reviewers track the current status of open PRs and plan time for review work
-  - Additional rounds of review SHOULD be completed until the PR can be either merged or closed
-  - To help track PR status teams MAY use GitHub labels (e.g. `Changes Requested`, `Needs Review` and `Ship It`) to help socialize status.
+All pull requests (PRs) **must** be reviewed by at least one other engineer before being merged. Exemptions to this rule require a specific, written policy agreed upon by the team and approved by an Engineering Manager or Director.
 
-- Engineers SHOULD utilize the Draft PR status to socialize work in progress and to solicit feedback
-  - Reviewers SHOULD NOT use the "request changes" option on draft PR reviews
-  - When a draft PR is ready for full review the requesting engineer MUST update its status and request (or re-request) review from relevant team members
+- **PR reviews are a core responsibility**
+  This isn't an "extra" task; it's a fundamental part of every engineer's job, regardless of level. Actively participating in reviews is crucial for code quality, knowledge sharing, and team success.
 
-# Peer Review
+- **Be timely & responsive**
+  Prioritize reviews to keep the development flow moving. Aim for initial feedback within a **24-48 hour** timeframe. If you have thoughts but can't give a full review, consider setting up a 30-minute walk-through with the author. After you have pushed updates based on feedback, **re-request a review** from the original reviewers to notify them that the PR is ready for another look. This helps everyone track the status and keeps the process moving.
 
-- All peer review MUST comply with our [Engineering Values](../culture/values.md)
+- **Be constructive & kind**
+  Focus on the code, not the person. Frame feedback as suggestions ("What do you think about trying...?") and questions ("Is there a reason we chose this approach?"). Avoid demands. Use "we" or "us" language where appropriate to foster a sense of shared ownership.
 
-- All work SHOULD go through the process of peer review. It is a form of collaboration and it strengthens quality.
+- **Understand the goal**
+  The PR author should provide a descriptive title and sufficient context in the PR description. As a reviewer, review the code against its stated purpose and acceptance criteria. Does the code achieve what it set out to do?
 
-- It SHOULD involve at least one (1) more experienced developer evaluating whether best practices are followed.
+- **Check for clarity & maintainability**
+  Is the code easy to understand? Are variable and function names clear? Will future developers be able to work with this? Look for opportunities to simplify, clarify, or refactor. Good code is not just clever; it's maintainable.
 
-- It MAY consist of at least one (1) session of one-on-one peer review.
+- **Verify functionality & tests**
+  Does the code work as expected? Are there adequate tests covering new functionality and edge cases? When necessary, pull down the branch and run the code locally to verify its behavior.
 
-  - Example: One team member would make an appointment with another team member to chat about coding progress, followed by walk-through of code-in-review.
+- **Encourage small, focused PRs**
+  Smaller PRs are easier and faster to review, lead to more thorough feedback, and reduce risk. Reviewers can and should request that large changes be broken down into smaller, logical PRs as a requirement for approval.
 
-- It MAY involve a team member who is less experienced with the tech stack.
+- **Use Draft PRs for early feedback**
+  For work-in-progress, use GitHub's "Draft" status to signal that a PR is not yet ready for a formal review. This is a great way to get early feedback on an approach without blocking reviewers. Reviewers should provide feedback on Draft PRs but should not use the "Request Changes" option until the PR is marked "Ready for Review."
 
-  - Example: A team member who is familiar with PHP can sit down with a team member familiar with Ruby on Rails, walking through the idea behind the PHP code, followed by a list concrete tests showing the code works.
+- **Approve when ready**
+  Don't hold up a PR for minor, non-blocking nits once the core functionality and quality are solid. Clearly communicate if a PR is ready to merge or if further changes are required. As a critical quality gate, a PR **must not** be merged if a reviewer has formally requested changes. Once all required changes are addressed and approved, the PR can be merged.
+
+- **Learn and share**
+  Use reviews as a chance to learn new approaches or share knowledge. Code reviews are a key part of mentorship and career growth, happening across teams, titles, and levels of experience. More junior engineers can and should review more senior code and vice versa. Remember to point out excellent solutions, not just areas for improvement.
+
+- **Automate where possible**
+  Utilize linters, formatters, and CI/CD pipelines to automatically handle style, formatting, and other mundane checks. This frees up human reviewers to focus on what they do best: assessing logic, architecture, and maintainability. Teams are encouraged to use features like `CODEOWNERS` files to automate reviewer assignments.

--- a/standards/peer-review.md
+++ b/standards/peer-review.md
@@ -2,13 +2,13 @@
 
 These guidelines establish the principles and processes for Pull Request (PR) reviews. Following them ensures we maintain high code quality, share knowledge effectively, and foster a collaborative and supportive engineering culture.
 
-All pull requests (PRs) **must** be reviewed by at least one other engineer before being merged. Exemptions to this rule require a specific, written policy agreed upon by the team and approved by an Engineering Manager or Director.
+All code **MUST** be reviewed by at least one other engineer before being merged.
 
 - **PR reviews are a core responsibility**
-  This isn't an "extra" task; it's a fundamental part of every engineer's job, regardless of level. Actively participating in reviews is crucial for code quality, knowledge sharing, and team success.
+  This isn't an "extra" task; it's a fundamental part of every engineer's job, regardless of level. Actively participating in reviews is crucial for code quality, knowledge sharing, and team success. Active participation will also help developers learn new techniques, improve communication skills, and learn to justify technical decisions, supporting personal growth as well as team outcomes.
 
 - **Be timely & responsive**
-  Prioritize reviews to keep the development flow moving. Aim for initial feedback within a **24-48 hour** timeframe. If you have thoughts but can't give a full review, consider setting up a 30-minute walk-through with the author. After you have pushed updates based on feedback, **re-request a review** from the original reviewers to notify them that the PR is ready for another look. This helps everyone track the status and keeps the process moving.
+  Prioritize reviews to keep the development flow moving. Aim for initial feedback within a **24-48 hour** timeframe. If you have thoughts but can't give a full review, consider setting up a 30-minute walk-through with the author. After you have pushed updates based on feedback, **re-request a review** from the original reviewers to notify them that the PR is ready for another look. If you think the notification might get missed, message your team on Slack (or use whatever works for your team) to let them know the PR has been updated. Do what works best to keep everyone in the loop and the process moving.
 
 - **Be constructive & kind**
   Focus on the code, not the person. Frame feedback as suggestions ("What do you think about trying...?") and questions ("Is there a reason we chose this approach?"). Avoid demands. Use "we" or "us" language where appropriate to foster a sense of shared ownership.
@@ -26,7 +26,7 @@ All pull requests (PRs) **must** be reviewed by at least one other engineer befo
   Smaller PRs are easier and faster to review, lead to more thorough feedback, and reduce risk. Reviewers can and should request that large changes be broken down into smaller, logical PRs as a requirement for approval.
 
 - **Use Draft PRs for early feedback**
-  For work-in-progress, use GitHub's "Draft" status to signal that a PR is not yet ready for a formal review. This is a great way to get early feedback on an approach without blocking reviewers. Reviewers should provide feedback on Draft PRs but should not use the "Request Changes" option until the PR is marked "Ready for Review."
+  Use GitHub's "Draft" status (or your team's conventions) to show a PR is not ready for formal review. "Draft" can mean either work in progress or a request for early feedback—be clear about your intent. Reviewers should give feedback on Draft PRs but avoid using "Request Changes" until the PR is marked "Ready for Review."
 
 - **Approve when ready**
   Don't hold up a PR for minor, non-blocking nits once the core functionality and quality are solid. Clearly communicate if a PR is ready to merge or if further changes are required. As a critical quality gate, a PR **must not** be merged if a reviewer has formally requested changes. Once all required changes are addressed and approved, the PR can be merged.


### PR DESCRIPTION
Updated PR review guidelines based on the breakout discussion groups from the 06/11/2025 engineering meeting

[Link to Figjam board](https://www.figma.com/board/p8BeKLxqPrQva59IjdK7pv/Pull-Request--PR--Review-Process-Brainstorm?node-id=0-1&t=x0cRnKj6txvY2qDY-1)